### PR TITLE
use correct .env file 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "^5.1",
-    "illuminate/config": "^5.1",
-    "illuminate/console": "^5.1",
-    "illuminate/database": "^5.1",
-    "illuminate/filesystem": "^5.1"
+    "illuminate/support": "5.x",
+    "illuminate/config": "5.x",
+    "illuminate/console": "5.x",
+    "illuminate/database": "5.x",
+    "illuminate/filesystem": "5.x"
   },
 
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "5.x",
-    "illuminate/config": "5.x",
-    "illuminate/console": "5.x",
-    "illuminate/database": "5.x",
-    "illuminate/filesystem": "5.x"
+    "illuminate/support": "^5.1",
+    "illuminate/config": "^5.1",
+    "illuminate/console": "^5.1",
+    "illuminate/database": "^5.1",
+    "illuminate/filesystem": "^5.1"
   },
 
   "require-dev": {

--- a/src/Commands/SetupTestDb.php
+++ b/src/Commands/SetupTestDb.php
@@ -20,28 +20,6 @@ class SetupTestDb extends Command
     protected $description = 'Sets up and seeds db for testing once per execution to save on re-seeding';
 
     /**
-     * loads env file (.env.something) based on environment set via --env=something.
-     *
-     * @return void
-     */
-	public function reloadEnvironment()
-	{
-        //$this->info("d1" . env('DB_CONNECTION'));
-        $this->info("Reload environment : " . \App::environment());
-		putenv('APP_ENV=' . \App::environment());
-		$this->laravel->make('Illuminate\Foundation\Bootstrap\DetectEnvironment')->bootstrap($this->laravel);
-		$envFile = \App::environmentFile();
-		if($envFile != ".env." . \App::environment()) {
-			$envFile = ".env." . \App::environment();
-		}
-		(new \Dotenv\Dotenv(\App::environmentPath(), $envFile ))->overload();
-		$this->laravel->make('Illuminate\Foundation\Bootstrap\LoadConfiguration')->bootstrap($this->laravel);
-        //$this->info("loaded DB_DATABASE : " . env('DB_DATABASE'));
-        //$this->info("d2" . \App::environmentPath());
-        //$this->info("d2" . \App::environmentFile());
-	}
-
-    /**
      * Execute the console command.
      *
      * @return mixed
@@ -49,9 +27,6 @@ class SetupTestDb extends Command
     public function handle()
     {
         $this->line("<question>[{$this->signature}]</question> starting the seeding");
-
-		$this->reloadEnvironment();
-		
 
         $config = $this->config();
 

--- a/src/Commands/SetupTestDb.php
+++ b/src/Commands/SetupTestDb.php
@@ -6,11 +6,11 @@ class SetupTestDb extends Command
 {
 
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'db:seed-test';
+    protected $name = 'db:seed-test';
 
     /**
      * The console command description.
@@ -24,17 +24,14 @@ class SetupTestDb extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function fire()
     {
-        $this->line("<question>[{$this->signature}]</question> starting the seeding");
+        $this->line("<question>[{$this->name}]</question> starting the seeding");
 
         $config = $this->config();
 
         $defaultConn = $config->get('database.default');
-        //$this->info("defaultConn :" . $defaultConn);
         $database = $config->get("database.connections.{$defaultConn}.database");
-        //$this->info("database :" . $database);
-
         $driver = $config->get("database.connections.{$defaultConn}.driver");
         if ($driver !== 'sqlite') {
             $this->info("Non-file based db detected: <comment>$driver</comment>");
@@ -55,12 +52,11 @@ class SetupTestDb extends Command
         ];
 
         $this->artisan('db:seed', $options);
-        $this->line("<question>[{$this->signature}]</question> db seeded!");
+        $this->line("<question>[{$this->name}]</question> db seeded!");
     }
 
     private function createDb($dbPath)
     {
-        //$this->info("Delete: <comment>{$dbPath}</comment>");
         $file = $this->fileSystem();
         $file->delete($dbPath);
         $file->put($dbPath, '');


### PR DESCRIPTION
- load env file based on environment set via --env, i.e.  --env=something will load settings from .env.something
- support for Laravel 5.1 (tested with 5.3)

these changes are needed to fix issue when command is called directly from console, i.e. if something like 
```
./artisan db:seed-test --env=testing
```
is called, then script uses values from .env (and not from .env.testing) 

so update forces use of a correct db via reloading environment/configuration based on passed value from --env 